### PR TITLE
Error messages with better context

### DIFF
--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -385,7 +385,7 @@ pub enum OsmosisError {
     Std(#[from] StdError),
 
     #[error("{0}")]
-    Overlow(#[from] cosmwasm_std::OverflowError),
+    Overflow(#[from] cosmwasm_std::OverflowError),
 
     #[error("Asset not in pool")]
     AssetNotInPool,


### PR DESCRIPTION
rebased on top of https://github.com/confio/osmosis-bindings/pull/23

While working with library (especially in tests) it is confusing and time consuming to read through random panics in code and error messages without much context.
This is my proposition of improvements.

`.checked_div` is not available yet, so I left it as it is