### PR TITLE
Remove sender from estimate swap

### DIFF
--- a/packages/bindings-test/src/multitest.rs
+++ b/packages/bindings-test/src/multitest.rs
@@ -473,7 +473,6 @@ impl Module for OsmosisModule {
                 Ok(to_binary(&SpotPriceResponse { price })?)
             }
             OsmosisQuery::EstimateSwap {
-                sender: _sender,
                 first,
                 route,
                 amount,
@@ -715,7 +714,6 @@ mod tests {
 
         // estimate the price (501505 * 0.997 = 500_000) after fees gone
         let query = OsmosisQuery::estimate_swap(
-            MOCK_CONTRACT_ADDR,
             pool_id,
             &coin_b.denom,
             &coin_a.denom,
@@ -728,7 +726,6 @@ mod tests {
 
         // now try the reverse query. we know what we need to pay to get 1.5M out
         let query = OsmosisQuery::estimate_swap(
-            MOCK_CONTRACT_ADDR,
             pool_id,
             &coin_b.denom,
             &coin_a.denom,
@@ -1056,7 +1053,6 @@ mod tests {
 
         // estimate the price (501505 * 0.997 = 500_000) after fees gone
         let query = OsmosisQuery::estimate_swap(
-            MOCK_CONTRACT_ADDR,
             1,
             "atom",
             "btc",
@@ -1069,7 +1065,6 @@ mod tests {
 
         // now try the reverse query. we know what we need to pay to get 1.5M out
         let query = OsmosisQuery::estimate_swap(
-            MOCK_CONTRACT_ADDR,
             1,
             "atom",
             "btc",

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -23,12 +23,9 @@ pub enum OsmosisQuery {
     /// We will add TWAP for more robust price feed.
     SpotPrice { swap: Swap, with_swap_fee: bool },
     /// Return current spot price swapping In for Out on given pool ID.
-    /// You can call `EstimateSwap { contract: env.contract.address, ... }` to set sender to the
-    /// current contract.
     /// Warning: this can easily be manipulated via sandwich attacks, do not use as price oracle.
     /// We will add TWAP for more robust price feed.
     EstimateSwap {
-        sender: String,
         first: Swap,
         route: Vec<Step>,
         amount: SwapAmount,
@@ -65,14 +62,12 @@ impl OsmosisQuery {
 
     /// Basic helper to estimate price of a swap on one pool
     pub fn estimate_swap(
-        contract: impl Into<String>,
         pool_id: u64,
         denom_in: impl Into<String>,
         denom_out: impl Into<String>,
         amount: SwapAmount,
     ) -> Self {
         OsmosisQuery::EstimateSwap {
-            sender: contract.into(),
             first: Swap::new(pool_id, denom_in, denom_out),
             amount,
             route: vec![],


### PR DESCRIPTION
Per changes in https://github.com/osmosis-labs/osmosis/pull/2764, removes sender from estimate swap